### PR TITLE
Update MetricManager initialization and Matthiesen Lib API to 1.5.2

### DIFF
--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/CobblemonBoosters.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/CobblemonBoosters.java
@@ -29,7 +29,7 @@ public final class CobblemonBoosters {
 
     public void initialize() {
         INSTANCE = this;
-        MetricManager.ready();
+        MetricManager.init();
         this.reload(false);
         PermissionRegistry.init();
         CommandRegistry.init();

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/MetricManager.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/MetricManager.java
@@ -5,25 +5,17 @@ import dev.matthiesen.common.matthiesen_lib_api.MatthiesenLibApi;
 import dev.matthiesen.common.matthiesen_lib_api.core.MatthiesenLibApiMetricsManager;
 import dev.matthiesen.common.matthiesen_lib_api.core.metric.UniversalMetricContext;
 import dev.matthiesen.libs.faststats.ErrorTracker;
-import dev.matthiesen.libs.faststats.Metrics;
 
 @SuppressWarnings("unused")
 public final class MetricManager {
     public static final ErrorTracker ERROR_TRACKER = MatthiesenLibApiMetricsManager.getErrorTracker();
-    private static final UniversalMetricContext metricContext = new UniversalMetricContext.Factory(
+    private static final UniversalMetricContext metricContext = MatthiesenLibApi.makeErrorMetricsContext(
             Constants.MOD_ID,
-            Constants.METRICS_TOKEN
-    )
-            .metrics(Metrics.Factory::create)
-            .errorTrackerService(ERROR_TRACKER)
-            .create();
+            Constants.METRICS_TOKEN,
+            ERROR_TRACKER
+    );
 
-    public static UniversalMetricContext getMetricContext() {
-        return metricContext;
-    }
-
-    public static void ready() {
-        MatthiesenLibApi.registerModToMetrics(Constants.MOD_ID);
-        metricContext.ready();
+    public static void init() {
+        MatthiesenLibApi.registerModToApiMetrics(Constants.MOD_ID);
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ kotlin-for-forge = "5.10.0"
 cobblemon = "1.7.3+1.21.1"
 gooeylibs = "3.1.1-1.21.x"
 publish = "0.35.0"
-matthiesen_lib_api = "1.5.1"
+matthiesen_lib_api = "1.5.2"
 matthiesen_lib_webhooks = "1.0.0"
 
 [plugins]


### PR DESCRIPTION
This pull request updates the way metrics are initialized and managed in the project, primarily by refactoring the `MetricManager` and updating the dependency on `matthiesen_lib_api`. The changes aim to simplify metric context creation and initialization, and ensure compatibility with the latest version of the metrics library.

Dependency Update:

* Updated the `matthiesen_lib_api` dependency version from `1.5.1` to `1.5.2` in `gradle/libs.versions.toml` to use the latest features and fixes.

Metrics Initialization Refactor:

* Replaced the manual construction of `UniversalMetricContext` with a call to `MatthiesenLibApi.makeErrorMetricsContext`, simplifying the setup and ensuring error tracking is integrated.
* Removed the `getMetricContext` and `ready` methods from `MetricManager`, replacing them with a new `init` method that registers the mod to the API metrics using the updated library API.
* Updated the `CobblemonBoosters.initialize()` method to call `MetricManager.init()` instead of the removed `MetricManager.ready()`.