### PR TITLE
Fix catch rate calculation to support values up to 255

### DIFF
--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/BoostManager.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/BoostManager.java
@@ -40,7 +40,7 @@ public final class BoostManager {
                     CobblemonEvents.POKEMON_CATCH_RATE,
                     (boost, event) -> {
                         float baseCatchRate = event.getCatchRate();
-                        event.setCatchRate(Math.min(baseCatchRate * boost.getMultiplier(), 1F));
+                        event.setCatchRate(Math.min(baseCatchRate * boost.getMultiplier(), 255F));
                     }
             );
     private static final BoostRecord<ExperienceBoost, ExperienceGainedEvent.Pre> EXPERIENCE_RECORD =


### PR DESCRIPTION
This pull request updates the catch rate calculation logic in the `BoostManager` for Pokémon catch events. The main change is to increase the upper limit for the catch rate multiplier, allowing boosted catch rates to go up to 255 instead of being capped at 1.

**Catch Rate Calculation Update:**

* In `BoostManager.java`, the maximum catch rate after applying a boost is now capped at 255F instead of 1F, allowing higher catch rates with boosts.