### PR TITLE
Add CoreConfig and implement runtime cache saving mechanism

### DIFF
--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/CobblemonBoosters.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/CobblemonBoosters.java
@@ -69,6 +69,10 @@ public final class CobblemonBoosters {
         Constants.createInfoLog("Reloaded Cobblemon Boosters configs");
     }
 
+    public ConfigManager<CoreConfig> getCoreConfigManager() {
+        return BoostersConfigManager.getCoreConfigManager();
+    }
+
     public ConfigManager<CacheConfig> getCacheConfigManager() {
          return BoostersConfigManager.getCacheConfigManager();
     }

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/Constants.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/Constants.java
@@ -1,9 +1,6 @@
 package dev.matthiesen.common.cobblemon_boosters;
 
-import dev.matthiesen.common.cobblemon_boosters.config.CacheConfig;
-import dev.matthiesen.common.cobblemon_boosters.config.MessagesConfig;
-import dev.matthiesen.common.cobblemon_boosters.config.PermissionsConfig;
-import dev.matthiesen.common.cobblemon_boosters.config.WebhooksConfig;
+import dev.matthiesen.common.cobblemon_boosters.config.*;
 import dev.matthiesen.libs.faststats.Token;
 import net.minecraft.resources.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
@@ -26,7 +23,8 @@ public final class Constants {
         CACHE("cache", CacheConfig.class),
         MESSAGES("messages", MessagesConfig.class),
         PERMISSIONS("permissions", PermissionsConfig.class),
-        WEBHOOKS("webhooks", WebhooksConfig.class);
+        WEBHOOKS("webhooks", WebhooksConfig.class),
+        CORE("core", CoreConfig.class);
 
         private final String configName;
         private final Class<?> configClass;

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/config/BoostersConfigManager.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/config/BoostersConfigManager.java
@@ -28,11 +28,19 @@ public final class BoostersConfigManager<T> extends ConfigManager<T> {
         }
     }
 
+    public static void saveCache() {
+        getCacheConfigManager().saveConfig();
+    }
+
     public static void loadAll() {
         for (Map.Entry<Constants.CONFIGS, ConfigManager<?>> entry : configManagers.entrySet()) {
             Constants.LOGGER.info("Loading config: {}", entry.getKey().getConfigName());
             entry.getValue().loadConfig();
         }
+    }
+
+    public static ConfigManager<CoreConfig> getCoreConfigManager() {
+        return getTypedConfigManager(Constants.CONFIGS.CORE);
     }
 
     public static ConfigManager<CacheConfig> getCacheConfigManager() {

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/config/CoreConfig.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/config/CoreConfig.java
@@ -1,0 +1,17 @@
+package dev.matthiesen.common.cobblemon_boosters.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+
+public final class CoreConfig {
+
+    @SerializedName("saveIntervalTicks")
+    public int saveIntervalTicks = 1200;
+
+    @SuppressWarnings("unused")
+    public static final Gson GSON = new GsonBuilder()
+            .disableHtmlEscaping()
+            .setPrettyPrinting()
+            .create();
+}

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/TickManager.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/TickManager.java
@@ -11,13 +11,9 @@ import net.minecraft.server.MinecraftServer;
 
 public final class TickManager {
     private static int tickCounter = 0;
-    private static Integer saveIntervalTicks = null;
 
     public static int getSaveIntervalTicks() {
-        if (saveIntervalTicks == null) {
-            saveIntervalTicks = CobblemonBoosters.INSTANCE.getCoreConfigManager().getConfig().saveIntervalTicks;
-        }
-        return saveIntervalTicks;
+        return CobblemonBoosters.INSTANCE.getCoreConfigManager().getConfig().saveIntervalTicks;
     }
 
     public static void tick() {
@@ -25,7 +21,8 @@ public final class TickManager {
             tickBoosts();
             updateBossBars();
             tickCounter++;
-            if (tickCounter >= getSaveIntervalTicks()) {
+            var saveInterval = getSaveIntervalTicks();
+            if (tickCounter >= saveInterval) {
                 tickCounter = 0;
                 BoostersConfigManager.saveCache();
             }

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/TickManager.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/TickManager.java
@@ -2,6 +2,7 @@ package dev.matthiesen.common.cobblemon_boosters.managers;
 
 import dev.matthiesen.common.cobblemon_boosters.CobblemonBoosters;
 import dev.matthiesen.common.cobblemon_boosters.Constants;
+import dev.matthiesen.common.cobblemon_boosters.config.BoostersConfigManager;
 import dev.matthiesen.common.cobblemon_boosters.config.CacheConfig;
 import dev.matthiesen.common.cobblemon_boosters.config.WebhooksConfig;
 import dev.matthiesen.common.cobblemon_boosters.interfaces.IBoost;
@@ -9,10 +10,25 @@ import dev.matthiesen.common.matthiesen_lib_api.MatthiesenLibApi;
 import net.minecraft.server.MinecraftServer;
 
 public final class TickManager {
+    private static int tickCounter = 0;
+    private static Integer saveIntervalTicks = null;
+
+    public static int getSaveIntervalTicks() {
+        if (saveIntervalTicks == null) {
+            saveIntervalTicks = CobblemonBoosters.INSTANCE.getCoreConfigManager().getConfig().saveIntervalTicks;
+        }
+        return saveIntervalTicks;
+    }
+
     public static void tick() {
         try {
             tickBoosts();
             updateBossBars();
+            tickCounter++;
+            if (tickCounter >= getSaveIntervalTicks()) {
+                tickCounter = 0;
+                BoostersConfigManager.saveCache();
+            }
         } catch (IllegalArgumentException e) {
             MetricManager.ERROR_TRACKER.trackError(e);
             Constants.LOGGER.error("Caught BossBar exception! ", e);


### PR DESCRIPTION
This pull request introduces a new core configuration system to the project, enabling configurable save intervals for cache persistence and centralizing core settings management. The main changes include the addition of a `CoreConfig` class, updates to configuration management to support the new core config, and logic in the tick manager to periodically save the cache based on the configurable interval.

**Core configuration system:**

* Added a new `CoreConfig` class with a `saveIntervalTicks` field and appropriate GSON serialization support.
* Updated the `CONFIGS` enum in `Constants.java` to include a `CORE` configuration type for managing core settings.
* Added a method to retrieve the core config manager in both `BoostersConfigManager` and `CobblemonBoosters`. [[1]](diffhunk://#diff-03962cc258065546e118d1bb98bebd03975d90fad9eca2c986e71153328c8c1eR31-R45) [[2]](diffhunk://#diff-b13dd0ab0c41cf041c0759389adce909760cc341b7596c9251449db2b5c06887R72-R75)

**Periodic cache saving:**

* Implemented logic in `TickManager` to periodically save the cache configuration based on the `saveIntervalTicks` value from `CoreConfig`, with a static counter and getter for the interval, instead of relying only on in-memory and shutdown time saving.
* Added a `saveCache` method to `BoostersConfigManager` for saving only the cache configuration.

**Code cleanup:**

* Simplified imports in `Constants.java` by using a wildcard import for config classes.