### PR TITLE
Update dependencies for Matthiesen Lib API and Webhooks

### DIFF
--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/config/WebhooksConfig.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/config/WebhooksConfig.java
@@ -3,7 +3,7 @@ package dev.matthiesen.common.cobblemon_boosters.config;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
-import dev.matthiesen.common.matthiesen_lib_webhooks.discord.DiscordColor;
+import dev.matthiesen.common.matthiesen_lib_api.core.discord.DiscordColor;
 
 import java.util.List;
 

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/webhook/DiscordWebhookService.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/webhook/DiscordWebhookService.java
@@ -8,8 +8,8 @@ import dev.matthiesen.common.cobblemon_boosters.interfaces.IWebhookService;
 import dev.matthiesen.common.cobblemon_boosters.managers.MetricManager;
 import dev.matthiesen.common.cobblemon_boosters.utils.TextUtils;
 import dev.matthiesen.common.matthiesen_lib_webhooks.MatthiesenLibWebhooks;
-import dev.matthiesen.common.matthiesen_lib_webhooks.discord.model.Embed;
-import dev.matthiesen.common.matthiesen_lib_webhooks.discord.model.EmbedBuilder;
+import dev.matthiesen.common.matthiesen_lib_api.core.discord.model.Embed;
+import dev.matthiesen.common.matthiesen_lib_api.core.discord.model.EmbedBuilder;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -18,10 +18,10 @@
   "depends": {
     "minecraft": "1.21.1",
     "cobblemon": ">=1.7.3 <1.8.0",
-    "matthiesen_lib_api": ">=1.5.8 <2.0.0"
+    "matthiesen_lib_api": ">=1.6.0 <2.0.0"
   },
   "suggests": {
     "cobbreeding": ">=2.0.0",
-    "matthiesen_lib_webhooks": ">=1.0.0 <2.0.0"
+    "matthiesen_lib_webhooks": ">=1.1.0 <2.0.0"
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,8 @@ kotlin-for-forge = "5.10.0"
 cobblemon = "1.7.3+1.21.1"
 gooeylibs = "3.1.1-1.21.x"
 publish = "0.35.0"
-matthiesen_lib_api = "1.5.8"
-matthiesen_lib_webhooks = "1.0.0"
+matthiesen_lib_api = "1.6.0"
+matthiesen_lib_webhooks = "1.1.0"
 
 [plugins]
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -37,7 +37,7 @@ side = "BOTH"
 [[dependencies.${mod_id}]]
 modId = "matthiesen_lib_api"
 mandatory = true
-versionRange = "[1.5.8,)"
+versionRange = "[1.6.0,)"
 ordering = "AFTER"
 side = "SERVER"
 
@@ -45,7 +45,7 @@ side = "SERVER"
 modId = "matthiesen_lib_webhooks"
 mandatory = false
 type = "optional"
-versionRange = "[1.0.0,)"
+versionRange = "[1.1.0,)"
 ordering = "AFTER"
 side = "SERVER"
 


### PR DESCRIPTION
This pull request updates the project's dependencies to newer versions of `matthiesen_lib_api` and `matthiesen_lib_webhooks` and adjusts import statements to match the updated package structure. These changes ensure compatibility with the latest versions of the libraries and maintain consistency across the codebase.

**Dependency version updates:**

* Updated the required version of `matthiesen_lib_api` from `1.5.8` to `1.6.0` and `matthiesen_lib_webhooks` from `1.0.0` to `1.1.0` in `fabric.mod.json`, `gradle/libs.versions.toml`, and `neoforge.mods.toml` to ensure compatibility with the latest features and bug fixes. [[1]](diffhunk://#diff-e380ecaaf1e9f72be30db395ad3f313674c314672bd1dbdf01362b582475a7cfL21-R25) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL15-R16) [[3]](diffhunk://#diff-86471e968eb4d8ee6fbb4e73fbbb71c7981f14158440d79d6c6f9e0b3164096bL40-R48)

**Code import updates:**

* Changed import statements in `WebhooksConfig.java` and `DiscordWebhookService.java` to use the new package paths for `DiscordColor`, `Embed`, and `EmbedBuilder` from `matthiesen_lib_api.core.discord` instead of `matthiesen_lib_webhooks.discord`. This reflects the library's restructuring and avoids deprecated or missing classes. [[1]](diffhunk://#diff-346e10a81739332725a7a4b219f2fe2ba02284ef531870d4d94e36903ebb130cL6-R6) [[2]](diffhunk://#diff-3d07d18ba90c9a99060575100b3613708c81b57be5799664158b23a8bc330803L11-R12)