### PR TITLE
Fixes BoostManager restoration system from server crash/reboot/shutdown

### DIFF
--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/config/CoreConfig.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/config/CoreConfig.java
@@ -9,6 +9,8 @@ public final class CoreConfig {
     @SerializedName("saveIntervalTicks")
     public int saveIntervalTicks = 1200;
 
+    public boolean verboseCacheLogging = false;
+
     @SuppressWarnings("unused")
     public static final Gson GSON = new GsonBuilder()
             .disableHtmlEscaping()

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/BoostManager.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/BoostManager.java
@@ -34,7 +34,8 @@ public final class BoostManager {
                     (boost, event) ->
                             event.addModificationFunction(((rate, player, pokemon) ->
                                     Math.max(rate / boost.getMultiplier(), 1))),
-                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeShinyBoost
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeShinyBoost,
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().queuedShinyBoosts
             );
     private static final BoostRecord<CatchBoost, PokemonCatchRateEvent> CATCH_RECORD =
             new BoostRecord<>(
@@ -44,7 +45,8 @@ public final class BoostManager {
                         float baseCatchRate = event.getCatchRate();
                         event.setCatchRate(Math.min(baseCatchRate * boost.getMultiplier(), 255F));
                     },
-                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeCatchBoost
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeCatchBoost,
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().queuedCatchBoosts
             );
     private static final BoostRecord<ExperienceBoost, ExperienceGainedEvent.Pre> EXPERIENCE_RECORD =
             new BoostRecord<>(
@@ -54,7 +56,8 @@ public final class BoostManager {
                         int exp = event.getExperience();
                         event.setExperience(Math.round(exp * boost.getMultiplier()));
                     },
-                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeExperienceBoost
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeExperienceBoost,
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().queuedExperienceBoosts
             );
     private static final BoostRecord<SpawnBucketBoost, SpawnBucketChosenEvent> SPAWN_BUCKET_RECORD =
             new BoostRecord<>(
@@ -64,7 +67,8 @@ public final class BoostManager {
                         SpawnBucket newBucket = SpawnBucketOverrideSelector.recalculateOverrideBucket(event, boost);
                         event.setBucket(newBucket);
                     },
-                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeSpawnBucketBoost
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeSpawnBucketBoost,
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().queuedSpawnBucketBoosts
             );
 
     public static void init() {}
@@ -142,11 +146,25 @@ public final class BoostManager {
         private final IBoostManager<T> manager;
 
         @SuppressWarnings("unused")
-        public BoostRecord(Class<T> boostClass, EventObservable<K> observable, BiConsumer<T, K> eventHandler, T activeBoost) {
+        public BoostRecord(Class<T> boostClass, EventObservable<K> observable, BiConsumer<T, K> eventHandler, T activeBoost, List<T> queue) {
             this.observable = observable;
             this.eventHandler = eventHandler;
-            this.queue = new LinkedList<>();
-            this.active = activeBoost;
+            if (!queue.isEmpty()) {
+                this.queue = new LinkedList<>(queue);
+                if (CobblemonBoosters.INSTANCE.getCoreConfigManager().getConfig().verboseCacheLogging) {
+                    Constants.createInfoLog("Re-Initializing BoostRecord for " + boostClass.getSimpleName() + " with non-empty queue. Queue size: " + queue.size());
+                }
+            } else {
+                this.queue = new LinkedList<>();
+            }
+            if (activeBoost != null) {
+                this.active = activeBoost;
+                if (CobblemonBoosters.INSTANCE.getCoreConfigManager().getConfig().verboseCacheLogging) {
+                    Constants.createInfoLog("Re-Initialized BoostRecord for " + boostClass.getSimpleName() + " with active boost: " + activeBoost.getMultiplier());
+                }
+            } else {
+                this.active = null;
+            }
             this.manager = new IBoostManager<>(() -> this.active, b -> this.active = b, this.queue);
             this.subscription = null;
         }

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/BoostManager.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/BoostManager.java
@@ -9,6 +9,7 @@ import com.cobblemon.mod.common.api.events.pokemon.ShinyChanceCalculationEvent;
 import com.cobblemon.mod.common.api.reactive.EventObservable;
 import com.cobblemon.mod.common.api.reactive.ObservableSubscription;
 import com.cobblemon.mod.common.api.spawning.SpawnBucket;
+import dev.matthiesen.common.cobblemon_boosters.CobblemonBoosters;
 import dev.matthiesen.common.cobblemon_boosters.Constants;
 import dev.matthiesen.common.cobblemon_boosters.data.CatchBoost;
 import dev.matthiesen.common.cobblemon_boosters.data.ExperienceBoost;
@@ -32,7 +33,8 @@ public final class BoostManager {
                     CobblemonEvents.SHINY_CHANCE_CALCULATION,
                     (boost, event) ->
                             event.addModificationFunction(((rate, player, pokemon) ->
-                                    Math.max(rate / boost.getMultiplier(), 1)))
+                                    Math.max(rate / boost.getMultiplier(), 1))),
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeShinyBoost
             );
     private static final BoostRecord<CatchBoost, PokemonCatchRateEvent> CATCH_RECORD =
             new BoostRecord<>(
@@ -41,7 +43,8 @@ public final class BoostManager {
                     (boost, event) -> {
                         float baseCatchRate = event.getCatchRate();
                         event.setCatchRate(Math.min(baseCatchRate * boost.getMultiplier(), 255F));
-                    }
+                    },
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeCatchBoost
             );
     private static final BoostRecord<ExperienceBoost, ExperienceGainedEvent.Pre> EXPERIENCE_RECORD =
             new BoostRecord<>(
@@ -50,7 +53,8 @@ public final class BoostManager {
                     (boost, event) -> {
                         int exp = event.getExperience();
                         event.setExperience(Math.round(exp * boost.getMultiplier()));
-                    }
+                    },
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeExperienceBoost
             );
     private static final BoostRecord<SpawnBucketBoost, SpawnBucketChosenEvent> SPAWN_BUCKET_RECORD =
             new BoostRecord<>(
@@ -59,7 +63,8 @@ public final class BoostManager {
                     (boost, event) -> {
                         SpawnBucket newBucket = SpawnBucketOverrideSelector.recalculateOverrideBucket(event, boost);
                         event.setBucket(newBucket);
-                    }
+                    },
+                    CobblemonBoosters.INSTANCE.getCacheConfigManager().getConfig().activeSpawnBucketBoost
             );
 
     public static void init() {}
@@ -137,11 +142,11 @@ public final class BoostManager {
         private final IBoostManager<T> manager;
 
         @SuppressWarnings("unused")
-        public BoostRecord(Class<T> boostClass, EventObservable<K> observable, BiConsumer<T, K> eventHandler) {
+        public BoostRecord(Class<T> boostClass, EventObservable<K> observable, BiConsumer<T, K> eventHandler, T activeBoost) {
             this.observable = observable;
             this.eventHandler = eventHandler;
             this.queue = new LinkedList<>();
-            this.active = null;
+            this.active = activeBoost;
             this.manager = new IBoostManager<>(() -> this.active, b -> this.active = b, this.queue);
             this.subscription = null;
         }

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/TickManager.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/TickManager.java
@@ -24,7 +24,9 @@ public final class TickManager {
             var saveInterval = getSaveIntervalTicks();
             if (tickCounter >= saveInterval) {
                 tickCounter = 0;
-                Constants.createInfoLog("Saving Boosters to Cache...");
+                if (CobblemonBoosters.INSTANCE.getCoreConfigManager().getConfig().verboseCacheLogging) {
+                    Constants.createInfoLog("Saving Boosters to Cache...");
+                }
                 BoostersConfigManager.saveCache();
             }
         } catch (IllegalArgumentException e) {

--- a/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/TickManager.java
+++ b/common/src/main/java/dev/matthiesen/common/cobblemon_boosters/managers/TickManager.java
@@ -24,6 +24,7 @@ public final class TickManager {
             var saveInterval = getSaveIntervalTicks();
             if (tickCounter >= saveInterval) {
                 tickCounter = 0;
+                Constants.createInfoLog("Saving Boosters to Cache...");
                 BoostersConfigManager.saveCache();
             }
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
This pull request introduces enhanced state restoration and debugging capabilities for the boosters system. The main changes include persisting and restoring the state of boost queues and active boosts from cache, as well as adding a new configuration option for verbose logging to aid in debugging and monitoring cache operations.

**State persistence and restoration:**

* Updated all `BoostRecord` initializations in `BoostManager` to accept and restore `activeBoost` and `queuedBoosts` from the cache, ensuring that boost state is preserved across restarts. [[1]](diffhunk://#diff-1ff120ebc3732ecb8da41194300af5efefd3f8162045851953adc3692597a208L35-R38) [[2]](diffhunk://#diff-1ff120ebc3732ecb8da41194300af5efefd3f8162045851953adc3692597a208L44-R49) [[3]](diffhunk://#diff-1ff120ebc3732ecb8da41194300af5efefd3f8162045851953adc3692597a208L53-R60) [[4]](diffhunk://#diff-1ff120ebc3732ecb8da41194300af5efefd3f8162045851953adc3692597a208L62-R71)
* Modified the `BoostRecord` constructor to initialize the queue and active boost from cached values, with optional logging if verbose mode is enabled.

**Debugging and logging improvements:**

* Added a new `verboseCacheLogging` boolean option to `CoreConfig`, allowing detailed logging of cache-related actions for easier troubleshooting.
* Inserted verbose logging statements in `TickManager.tick()` and `BoostRecord` to log when the boosters cache is being saved and when boost records are re-initialized from cache, controlled by the new config option. [[1]](diffhunk://#diff-15b790789b351eaf4e44ca1e2ab66fb66fbd3c590a2b340f4755d530b418193cR27-R29) [[2]](diffhunk://#diff-1ff120ebc3732ecb8da41194300af5efefd3f8162045851953adc3692597a208L140-R167)